### PR TITLE
Efficient povm operator

### DIFF
--- a/jvmc_utilities/__init__.py
+++ b/jvmc_utilities/__init__.py
@@ -1,4 +1,4 @@
-from .operators import initialisation_operators, higher_order_M_T_inv, aqi_model_operators
+from .operators import initialisation_operators, higher_order_M_T_inv, aqi_model_operators, EfficientPOVMOperator
 from .measurement import Measurement
 from .time_evolve import Initializer, copy_state
 from . import nets


### PR DESCRIPTION
Implemented a more efficient `POVMOperator` class.

This class uses the fact that the s_prime configurations will often (around 30% of the time) be multiplied by a matrixElement weight of 0, making them irrelevant. The `EfficientPOVMOperator` class will not evaluate the neural network for these configurations but just assign them a value of 0.